### PR TITLE
Update daily menu notifier schedule

### DIFF
--- a/.github/workflows/menu_notifier.yml
+++ b/.github/workflows/menu_notifier.yml
@@ -2,9 +2,10 @@ name: School Menu Notifier
 
 on:
   schedule:
-    # Run every weekday at 5:00 PM MDT/MST (11:00 PM UTC)
+    # Run Monday-Thursday and Sunday at 4:00 PM MDT/MST (10:00 PM UTC)
     # This ensures the menu for the next day is available
-    - cron: '0 23 * * 1-5'
+    # Sunday covers Monday's menu, Monday-Thursday cover Tuesday-Friday respectively
+    - cron: '0 22 * * 0,1-4'
   
   # Allow manual triggering
   workflow_dispatch:


### PR DESCRIPTION
- Change time from 5 PM to 4 PM Mountain Time (10 PM UTC)
- Run Monday-Thursday and Sunday (skip Friday)
- Sunday covers Monday's menu
- Maintains DST support through UTC scheduling